### PR TITLE
Api key reqd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config/application.yml

--- a/app/controllers/votes_app.rb
+++ b/app/controllers/votes_app.rb
@@ -22,9 +22,13 @@ class VotesApp < Sinatra::Base
   end
 
   get '/api/v1/:votable_type/:votable_id/update_vote/:id/:user_token/:rating' do
-    updated_vote = Vote.update_vote(params[:id], params[:rating])
+    if api_key_valid?
+      updated_vote = Vote.update_vote(params[:id], params[:rating])
 
-    json VoteSerializer.new(updated_vote)
+      json VoteSerializer.new(updated_vote)
+    else
+      halt 401
+    end
   end
 
   private

--- a/app/controllers/votes_app.rb
+++ b/app/controllers/votes_app.rb
@@ -12,14 +12,24 @@ class VotesApp < Sinatra::Base
   end
 
   post '/api/v1/:votable_type/:votable_id/create_vote/:user_token/:rating' do
-    vote = Vote.check_previous(params)
+    if api_key_valid?
+      vote = Vote.check_previous(params)
 
-    json VoteSerializer.new(vote)
+      json VoteSerializer.new(vote)
+    else
+      halt 401
+    end
   end
 
   get '/api/v1/:votable_type/:votable_id/update_vote/:id/:user_token/:rating' do
     updated_vote = Vote.update_vote(params[:id], params[:rating])
 
     json VoteSerializer.new(updated_vote)
+  end
+
+  private
+
+  def api_key_valid?
+    ENV['VOTES_API_KEY'] && params[:api_key] == ENV['VOTES_API_KEY']
   end
 end

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -7,6 +7,7 @@ class Vote < ActiveRecord::Base
   enum votable_type: ["landmark", "recording", "tour"]
 
   def self.check_previous(params)
+    params.delete('api_key')
     votable_id = params["votable_id"]
     user_token = params["user_token"]
     votable_type = params["votable_type"]

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -15,6 +15,11 @@ Dir.glob(File.join(APP_ROOT, 'app', 'serializers', '*.rb')).each { |file| requir
 # require database configurations
 require File.join(APP_ROOT, 'config', 'database')
 
+Figaro.application = Figaro::Application.new(
+  path: File.expand_path("config/application.yml")
+)
+Figaro.load
+
 class VotesApp < Sinatra::Base
   set :method_override, true
   set :root, APP_ROOT

--- a/spec/requests/api/v1/landmark/allows_user_to_update_vote_spec.rb
+++ b/spec/requests/api/v1/landmark/allows_user_to_update_vote_spec.rb
@@ -2,7 +2,6 @@ require "./spec/spec_helper"
 
 describe "Allows a user to update a vote" do
   it "and this changes total score" do
-
     Vote.create(votable_id: 25, votable_type: "landmark", rating: -1, user_token: "12049oOwjhsfe")
     Vote.create(votable_id: 25, votable_type: "landmark", rating: -1, user_token: "348205whfna23afe")
     Vote.create(votable_id: 25, votable_type: "landmark", rating: -1, user_token: "348205okadefe")
@@ -27,7 +26,7 @@ describe "Allows a user to update a vote" do
     expect(ratings[:data][:attributes][:downvotes]).to eq(7)
     expect(ratings[:data][:attributes][:total_score]).to eq(-1)
 
-    get "/api/v1/landmark/25/update_vote/#{id}/0987asdf/-1"
+    get "/api/v1/landmark/25/update_vote/#{id}/0987asdf/-1?api_key=#{ENV['VOTES_API_KEY']}"
 
     expect(last_response).to be_ok
 

--- a/spec/requests/api/v1/landmark/creates_votes_for_landmark_spec.rb
+++ b/spec/requests/api/v1/landmark/creates_votes_for_landmark_spec.rb
@@ -25,7 +25,7 @@ describe "Create landmark Vote" do
     expect(ratings[:data][:attributes][:downvotes]).to eq(4)
     expect(ratings[:data][:attributes][:total_score]).to eq(4)
 
-    post '/api/v1/landmark/25/create_vote/19384uksjehf/-1'
+    post "/api/v1/landmark/25/create_vote/19384uksjehf/-1?api_key=#{ENV['VOTES_API_KEY']}"
 
     expect(last_response).to be_ok
     
@@ -45,5 +45,24 @@ describe "Create landmark Vote" do
     expect(ratings[:data][:attributes][:upvotes]).to eq(8)
     expect(ratings[:data][:attributes][:downvotes]).to eq(5)
     expect(ratings[:data][:attributes][:total_score]).to eq(3)
+  end
+
+  it 'will not allow vote to be created without valid API key' do
+    votable_type = 'landmark'
+    votable_id = 25
+
+    expect(Vote.relevant_votes(votable_id, votable_type).count).to eq(0)
+
+    post "/api/v1/#{votable_type}/#{votable_id}/create_vote/1234/-1?api_key=#{ENV['VOTES_API_KEY']}"
+    expect(last_response.status).to eq(200)
+    expect(Vote.relevant_votes(votable_id, votable_type).count).to eq(1)
+
+    post "/api/v1/#{votable_type}/#{votable_id}/create_vote/5678/-1?api_key=not_a_real_api_key"
+    expect(last_response.status).to eq(401)
+    expect(Vote.relevant_votes(votable_id, votable_type).count).to eq(1)
+    
+    post "/api/v1/#{votable_type}/#{votable_id}/create_vote/9101112/-1"
+    expect(last_response.status).to eq(401)
+    expect(Vote.relevant_votes(votable_id, votable_type).count).to eq(1)
   end
 end

--- a/spec/requests/api/v1/landmark/limits_votes_spec.rb
+++ b/spec/requests/api/v1/landmark/limits_votes_spec.rb
@@ -2,7 +2,6 @@ require "./spec/spec_helper"
 
 describe "User can only vote once" do
   it "then update is called" do
-
     Vote.create(votable_id: 60, votable_type: "landmark", rating: 1, user_token: "12345")
 
     Vote.create(votable_id: 60, votable_type: "landmark", rating: 1, user_token: "9834u")
@@ -25,8 +24,7 @@ describe "User can only vote once" do
     expect(original_vote[:data][:attributes][:downvotes]).to eq(2)
     expect(original_vote[:data][:attributes][:total_score]).to eq(2)
 
-    post '/api/v1/landmark/60/create_vote/12345/-1'
-
+    post "/api/v1/landmark/60/create_vote/12345/-1?api_key=#{ENV['VOTES_API_KEY']}"
 
     get '/api/v1/landmark/60/score'
 

--- a/spec/requests/api/v1/recording/allows_user_to_update_vote_for_recording_spec.rb
+++ b/spec/requests/api/v1/recording/allows_user_to_update_vote_for_recording_spec.rb
@@ -27,7 +27,7 @@ describe "Allows a user to update a vote" do
     expect(ratings[:data][:attributes][:downvotes]).to eq(1)
     expect(ratings[:data][:attributes][:total_score]).to eq(11)
 
-    get "/api/v1/recording/60/update_vote/#{id}/0987asdf/-1"
+    get "/api/v1/recording/60/update_vote/#{id}/0987asdf/-1?api_key=#{ENV['VOTES_API_KEY']}"
 
     expect(last_response).to be_ok
 

--- a/spec/requests/api/v1/recording/limits_user_create_spec.rb
+++ b/spec/requests/api/v1/recording/limits_user_create_spec.rb
@@ -2,7 +2,6 @@ require "./spec/spec_helper"
 
 describe "User can only vote once" do
   it "then update is called" do
-
     Vote.create(votable_id: 22, votable_type: "recording", rating: 1, user_token: "12345")
 
     Vote.create(votable_id: 22, votable_type: "recording", rating: 1, user_token: "9834u")
@@ -25,8 +24,7 @@ describe "User can only vote once" do
     expect(original_vote[:data][:attributes][:downvotes]).to eq(2)
     expect(original_vote[:data][:attributes][:total_score]).to eq(2)
 
-    post '/api/v1/recording/22/create_vote/12345/-1'
-
+    post "/api/v1/recording/22/create_vote/12345/-1?api_key=#{ENV['VOTES_API_KEY']}"
 
     get '/api/v1/recording/22/score'
 

--- a/spec/requests/api/v1/tour/allows_update_tour_spec.rb
+++ b/spec/requests/api/v1/tour/allows_update_tour_spec.rb
@@ -27,7 +27,7 @@ describe "Allows a user to update a vote" do
     expect(ratings[:data][:attributes][:downvotes]).to eq(1)
     expect(ratings[:data][:attributes][:total_score]).to eq(11)
 
-    get "/api/v1/tour/78/update_vote/#{id}/0987asdf/-1"
+    get "/api/v1/tour/78/update_vote/#{id}/0987asdf/-1?api_key=#{ENV['VOTES_API_KEY']}"
 
     expect(last_response).to be_ok
 

--- a/spec/requests/api/v1/tour/allows_user_to_vote_for_tour_spec.rb
+++ b/spec/requests/api/v1/tour/allows_user_to_vote_for_tour_spec.rb
@@ -2,7 +2,6 @@ require "./spec/spec_helper"
 
 describe "Create tour Vote" do
   it "Creates a vote for a tour, with an id, and changes total score" do
-
     Vote.create(votable_id: 78, votable_type: "tour", rating: 1, user_token: "12049oOwjhsfe")
     Vote.create(votable_id: 78, votable_type: "tour", rating: 1, user_token: "348205whfna23afe")
     Vote.create(votable_id: 78, votable_type: "tour", rating: 1, user_token: "348205okadefe")
@@ -26,7 +25,7 @@ describe "Create tour Vote" do
     expect(ratings[:data][:attributes][:downvotes]).to eq(3)
     expect(ratings[:data][:attributes][:total_score]).to eq(6)
 
-    post '/api/v1/tour/78/create_vote/19384uksjehf/-1'
+    post "/api/v1/tour/78/create_vote/19384uksjehf/-1?api_key=#{ENV['VOTES_API_KEY']}"
     expect(last_response).to be_ok
 
     vote = JSON.parse(last_response.body, symbolize_names: true)
@@ -45,5 +44,24 @@ describe "Create tour Vote" do
     expect(ratings[:data][:attributes][:upvotes]).to eq(9)
     expect(ratings[:data][:attributes][:downvotes]).to eq(4)
     expect(ratings[:data][:attributes][:total_score]).to eq(5)
+  end
+
+  it 'will not allow vote to be created without valid API key' do
+    votable_type = 'tour'
+    votable_id = 25
+
+    expect(Vote.relevant_votes(votable_id, votable_type).count).to eq(0)
+
+    post "/api/v1/#{votable_type}/#{votable_id}/create_vote/1234/-1?api_key=#{ENV['VOTES_API_KEY']}"
+    expect(last_response.status).to eq(200)
+    expect(Vote.relevant_votes(votable_id, votable_type).count).to eq(1)
+
+    post "/api/v1/#{votable_type}/#{votable_id}/create_vote/5678/-1?api_key=not_a_real_api_key"
+    expect(last_response.status).to eq(401)
+    expect(Vote.relevant_votes(votable_id, votable_type).count).to eq(1)
+    
+    post "/api/v1/#{votable_type}/#{votable_id}/create_vote/9101112/-1"
+    expect(last_response.status).to eq(401)
+    expect(Vote.relevant_votes(votable_id, votable_type).count).to eq(1)
   end
 end


### PR DESCRIPTION
Add requirement that create/update vote requests have a valid `api_key` parameter. Value stored in `config/application.yml` (and already added as an ENV variable in Heroku for both apps).